### PR TITLE
Add password hashing script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Proyecto Final Web
+
+Este repositorio contiene la aplicación y los scripts de base de datos.
+
+## Scripts
+
+- `Proyecto_Final_Web/SQLQuery_Crear_Tablas.sql` crea la estructura de la base de datos.
+- `Proyecto_Final_Web/SQLQuery_Poblar_Tablas.sql` inserta datos iniciales.
+- `Scripts/HashExistingPasswords.sql` genera hashes SHA-256 para las contraseñas existentes.
+
+## Actualización de contraseñas
+
+Después de desplegar los cambios que implementan el almacenamiento de contraseñas con hash, ejecute el script `Scripts/HashExistingPasswords.sql` en la base de datos para convertir las contraseñas guardadas en texto plano.

--- a/Scripts/HashExistingPasswords.sql
+++ b/Scripts/HashExistingPasswords.sql
@@ -1,0 +1,8 @@
+-- HashExistingPasswords.sql
+-- Actualiza las contraseñas de la tabla Usuarios usando SHA-256
+-- Ejecute este script después de desplegar los cambios que implementan
+-- el almacenamiento de contraseñas con hash.
+
+UPDATE [dbo].[Usuarios]
+SET [Contrasena] = CONVERT(VARCHAR(64), HASHBYTES('SHA2_256', [Contrasena]), 2)
+WHERE LEN([Contrasena]) <> 64 OR [Contrasena] LIKE '%[^0-9A-Fa-f]%';


### PR DESCRIPTION
## Summary
- add `Scripts/HashExistingPasswords.sql` to hash existing plain text passwords
- document database scripts and instructions in new `README.md`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c0793228832b99d8998224bd4235