### PR TITLE
Fix password hashing on user edit

### DIFF
--- a/Proyecto_Final_Web/Controllers/UsuariosController.cs
+++ b/Proyecto_Final_Web/Controllers/UsuariosController.cs
@@ -226,6 +226,18 @@ namespace Proyecto_Final_Web.Controllers
             {
                 try
                 {
+                    // Hashear la contraseña con SHA256 antes de actualizar
+                    using (SHA256 sha256Hash = SHA256.Create())
+                    {
+                        byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(usuario.Contrasena));
+                        StringBuilder builder = new StringBuilder();
+                        for (int i = 0; i < bytes.Length; i++)
+                        {
+                            builder.Append(bytes[i].ToString("x2"));
+                        }
+                        usuario.Contrasena = builder.ToString();
+                    }
+
                     _context.Update(usuario);
                     await _context.SaveChangesAsync();
                 }


### PR DESCRIPTION
## Summary
- hash passwords using SHA256 in `UsuariosController.Edit` before updating the user

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c1ef87b8832b98b8a28806d5dcc9